### PR TITLE
Update de links dos repositórios 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ Este repositório público **(ds25-organização)** centraliza informações sob
 
 ## Estrutura no GitHub
 
-- **GitHub Projects (Kanban)**: trabalhamos com um projeto no estilo Kanban para gerenciar o planejamento e a execução das tarefas.  
+- **GitHub Projects**: trabalhamos com um projeto no estilo Kanban para gerenciar o planejamento e a execução das tarefas. [Link](https://github.com/orgs/LABHDUFBA/projects/10)  
 - **Repositórios Privados**: teremos diversos repositórios privados conectados ao projeto principal, mantendo o fluxo de trabalho unificado no GitHub.  
+    - [ds25-elt](https://github.com/LABHDUFBA/ds25-elt)
+    - [ds25-analise-quali](https://github.com/LABHDUFBA/ds25-analise-quali)
+    - [ds25-analise-quanti](https://github.com/LABHDUFBA/ds25-analise-quanti/)
+    - [ds25-organizacao](https://github.com/LABHDUFBA/ds25-organizacao)
+
 - **Equipes**: atualmente contamos com três equipes:  
   - [**Suporte GitHub**](https://github.com/orgs/LABHDUFBA/teams/suporte-github): @suporte-github  
   - [**Computacional**](https://github.com/orgs/LABHDUFBA/teams/equipe-computacional): @equipe-computacional
@@ -15,10 +20,10 @@ Cada equipe tem atribuições específicas e colabora de forma integrada para cu
 
 ## Fluxo de Trabalho
 
-1. **Planejamento no Kanban**: as tarefas são registradas como *issues* ou *cards* no projeto Kanban do GitHub, onde recebem prioridade e responsáveis.  
+1. **Planejamento no Projeto do Github**: as tarefas são registradas como *issues* ou *cards* no projeto do GitHub, onde recebem prioridade e responsáveis.  
 2. **Desenvolvimento nos Repositórios Privados**: o trabalho efetivo acontece nos repositórios privados, seguindo as boas práticas de versionamento, CI/CD e documentação.  
 3. **Comunicação via Telegram**: utilizamos grupo no Telegram para discussões rápidas, alinhamento diário e atualizações de status.  
-4. **Integração e Revisão**: todas as *issues* fechadas e pull requests aprovadas são refletidas no Kanban, garantindo rastreabilidade e acompanhamento.
+4. **Integração e Revisão**: todas as *issues* fechadas e pull requests aprovadas são refletidas no projeto do Github, garantindo rastreabilidade e acompanhamento.
 
 ## Equipes e Colaboradoras(es)
 
@@ -27,7 +32,7 @@ Para visualizar quem faz parte de cada equipe e seus respectivos perfis GitHub, 
 
 ---
 
-## Contribuindo com Este Repositório
+## Contribuindo com este repositório
 
 Este repositório é público para que qualquer pessoa interessada em contribuir com correções, melhorias na documentação ou sugestões de novas abordagens possa participar.  
 - Você pode abrir uma [*issue*](../../issues) relatando problemas ou sugerindo mudanças.  

--- a/estrutura_repos.md
+++ b/estrutura_repos.md
@@ -3,7 +3,7 @@ title: "Estrutura de Repositórios"
 date: 2025-02-25
 ---
 
-1. ds25-etl
-2. ds25-analise-quali
-3. ds25-analise-quanti
-4. ds25-organização
+1. [**ds25-etl**](https://github.com/LABHDUFBA/ds25-elt/)  
+2. [**ds25-analise-quali** ](https://github.com/LABHDUFBA/ds25-analise-quali) 
+3. [**ds25-analise-quanti**](https://github.com/LABHDUFBA/ds25-analise-quanti/)  
+4. [**ds25-organização** ](https://github.com/LABHDUFBA/ds25-organizacao/) 


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `estrutura_repos.md` files to improve documentation clarity and add links to relevant repositories. The most important changes include updating the naming conventions for project planning, adding links to private repositories, and correcting formatting in the contribution section.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R13): Updated the naming convention from "Kanban" to "Projeto do Github" for consistency and added links to private repositories such as `ds25-elt`, `ds25-analise-quali`, `ds25-analise-quanti`, and `ds25-organizacao`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R26)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R35): Corrected the capitalization in the section title "Contribuindo com este repositório" for consistency.
* [`estrutura_repos.md`](diffhunk://#diff-3ef357aa41a6e16b169f7237829f0ad3cf497798687e1c4ab32fdda7500c1b6bL6-R9): Added hyperlinks to the repository names to facilitate easy navigation to `ds25-etl`, `ds25-analise-quali`, `ds25-analise-quanti`, and `ds25-organizacao`.

**OBS**: Texto gerado automaticamente pelo Github Copilot