### PR TITLE
Inclusão da Equipe quantitativa

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Este repositório público **(ds25-organização)** centraliza informações sob
   - [**Suporte GitHub**](https://github.com/orgs/LABHDUFBA/teams/suporte-github): @suporte-github  
   - [**Computacional**](https://github.com/orgs/LABHDUFBA/teams/equipe-computacional): @equipe-computacional
   - [**Qualitativa**](https://github.com/orgs/LABHDUFBA/teams/equipe-qualitativa): @equipe-qualitativa
+  - [**Quantitativa**](https://github.com/orgs/LABHDUFBA/teams/equipe-quantitativa): @equipe-quantitativa
 
 Cada equipe tem atribuições específicas e colabora de forma integrada para cumprir os objetivos do projeto.
 


### PR DESCRIPTION
Este *pull request* traz uma pequena alteração no arquivo `README.md`, adicionando a equipe **Quantitativa** à lista de equipes com seus respectivos perfis no GitHub.