### PR TITLE
Correções dos templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-issue-padrao.md
+++ b/.github/ISSUE_TEMPLATE/1-issue-padrao.md
@@ -23,11 +23,11 @@ projects:
 
 ---
 
-## ** Após a criação da issue**
+## **Após a criação da issue**
 
 Marque os seguintes dados relativos ao projeto na **aba lateral direita** conforme a imagem:
 
-![](projects_meta.png):
+![](https://raw.githubusercontent.com/LABHDUFBA/ds25-organizacao/refs/heads/main/.github/ISSUE_TEMPLATE/projects_meta.png):
 
 ### **Status**
 

--- a/.github/ISSUE_TEMPLATE/2-bug.md
+++ b/.github/ISSUE_TEMPLATE/2-bug.md
@@ -69,7 +69,7 @@ Adicione qualquer outro contexto relevante sobre o problema, logs de erro ou sol
 
 Marque os seguintes dados relativos ao projeto na **aba lateral direita** conforme a imagem:
 
-![](projects_meta.png)
+![](https://raw.githubusercontent.com/LABHDUFBA/ds25-organizacao/refs/heads/main/.github/ISSUE_TEMPLATE/projects_meta.png):
 
 ### **Status**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "Discuções"
+  - name: "Discussões"
     url: https://github.com/LABHDUFBA/ds25-organizacao/discussions
     about: Para preguntas sobre sobre o projeto ou o repositorio crie um tópico na DISCUSSÃO
   - name: "Contato com o LABHDUFBA"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: "Discussões"
     url: https://github.com/LABHDUFBA/ds25-organizacao/discussions


### PR DESCRIPTION
This pull request includes several updates to the GitHub issue templates and configuration. The changes primarily focus on updating image URLs, disabling blank issues, and correcting text.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/1-issue-padrao.md`](diffhunk://#diff-1f3a1ec7c421e6288c8c171b9dfa8115eb10be15f31a61ef7002bf54b75ca9f1L30-R30): Updated the image URL for project metadata to point to the correct location on GitHub.
* [`.github/ISSUE_TEMPLATE/2-bug.md`](diffhunk://#diff-2925a55f915ea737ca57a4339bc2d79d5c16d01fe3505e270414875fcf97cac4L72-R72): Updated the image URL for project metadata to point to the correct location on GitHub.

Configuration changes:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L1-R3): Disabled blank issues and corrected the name for the discussions link.