### PR TITLE
Adiciona automação para notificar issues inativas

### DIFF
--- a/.github/workflows/notify-inactive-issues.yml
+++ b/.github/workflows/notify-inactive-issues.yml
@@ -1,0 +1,25 @@
+name: 🔄 Notificação de Issues Inativas
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # Executa diariamente às 12h UTC
+
+permissions:
+  issues: write  # Permite escrever em issues
+
+jobs:
+  notify-inactive-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📌 Marcar Issues Inativas
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 10  # Define inatividade após 10 dias
+          days-before-close: 30  # Opcional: fecha a issue após 30 dias sem resposta
+          stale-issue-label: "inativa"  # Adiciona a label "inativa" às issues sem atividade
+          stale-issue-message: |
+            🚨 Esta issue está inativa há mais de 10 dias.  
+            @${{ github.event.issue.assignee }} por favor, atualize o status ou comente para evitar o fechamento automático.
+          close-issue-message: |
+            ⚠️ Esta issue foi fechada automaticamente por inatividade. Se necessário, reabra ou crie uma nova.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to notify and manage inactive issues in the repository. The workflow is scheduled to run daily and uses the `actions/stale` action to mark and close inactive issues.

Key changes include:

* [`.github/workflows/notify-inactive-issues.yml`](diffhunk://#diff-f427263d543509c41688d49720d87fb8d73d39929b887791ef472301c6e634afR1-R25): Added a new workflow named "🔄 Notificação de Issues Inativas" that runs daily at 12 PM UTC. It marks issues as inactive after 10 days of inactivity and optionally closes them after 30 days without a response.