### PR TITLE
Update notify-inactive-issues.yml

### DIFF
--- a/.github/workflows/notify-inactive-issues.yml
+++ b/.github/workflows/notify-inactive-issues.yml
@@ -2,7 +2,7 @@ name: 🔄 Notificação de Issues Inativas
 
 on:
   schedule:
-    - cron: '0 12 * * *'  # Executa diariamente às 12h UTC
+    - cron: '0 16 * * *'  # Executa diariamente às 16h UTC
 
 permissions:
   issues: write  # Permite escrever em issues
@@ -15,11 +15,15 @@ jobs:
         uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 10  # Define inatividade após 10 dias
+          days-before-stale: 7  # Define inatividade após 7 dias
           days-before-close: 30  # Opcional: fecha a issue após 30 dias sem resposta
           stale-issue-label: "inativa"  # Adiciona a label "inativa" às issues sem atividade
           stale-issue-message: |
-            🚨 Esta issue está inativa há mais de 10 dias.  
-            @${{ github.event.issue.assignee }} por favor, atualize o status ou comente para evitar o fechamento automático.
+            🚨 Esta issue está inativa há mais de 7 dias.
+            
+            Responsável atribuído, por favor, atualize ou comente para evitar o fechamento automático.  
+            Se você é o responsável, essa mensagem é para você. 👀
+            
+            🔔 @LABHDUFBA/suporte-github
           close-issue-message: |
             ⚠️ Esta issue foi fechada automaticamente por inatividade. Se necessário, reabra ou crie uma nova.


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for notifying inactive issues. The key changes involve adjusting the schedule and modifying the inactivity parameters and messages.

Workflow schedule adjustment:

* [`.github/workflows/notify-inactive-issues.yml`](diffhunk://#diff-f427263d543509c41688d49720d87fb8d73d39929b887791ef472301c6e634afL5-R5): Changed the cron schedule to run daily at 16:00 UTC instead of 12:00 UTC.

Inactivity parameters and messages:

* [`.github/workflows/notify-inactive-issues.yml`](diffhunk://#diff-f427263d543509c41688d49720d87fb8d73d39929b887791ef472301c6e634afL18-R27): Reduced the inactivity period from 10 days to 7 days before marking an issue as stale.
* [`.github/workflows/notify-inactive-issues.yml`](diffhunk://#diff-f427263d543509c41688d49720d87fb8d73d39929b887791ef472301c6e634afL18-R27): Updated the stale issue message to reflect the new inactivity period and added a more personalized message for the assigned responsible person.